### PR TITLE
Add support for batch=ok inserts

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -289,7 +289,7 @@ class Database(object):
         (resp, result) = self.resource(*_id_to_path(id)).get(params=params)
         return result
 
-    def save(self, doc):
+    def save(self, doc, batch=False):
         """
         Save or update a document.
 
@@ -297,6 +297,7 @@ class Database(object):
             Now returns a new document instead of modify the original.
 
         :param doc: document
+        :param batch: allow batch=ok inserts (default False)
         :raises: :py:exc:`~pycouchdb.exceptions.Conflict` if save with wrong
                  revision.
         :returns: doc
@@ -306,8 +307,13 @@ class Database(object):
         if "_id" not in _doc:
             _doc['_id'] = uuid.uuid4().hex
 
+        if batch:
+            params = { 'batch': 'ok' }
+        else:
+            params = {}
+
         data = utils.force_bytes(utils.to_json(_doc))
-        (resp, result) = self.resource(_doc['_id']).put(data=data)
+        (resp, result) = self.resource(_doc['_id']).put(data=data, params=params)
 
         if resp.status_code == 409:
             raise exp.Conflict(result['reason'])

--- a/tests.py
+++ b/tests.py
@@ -116,6 +116,11 @@ class DatabaseTests(unittest.TestCase):
         with self.assertRaises(Conflict):
             doc2 = self.db.save(doc)
 
+    def test_save_batch(self):
+        doc = {"foo": "bar"}
+        doc2 = self.db.save(doc, batch=True)
+        self.assertIn("_id", doc2)
+
     def test_special_chars1(self):
         text="Lürem ipsüm."
         self.db.save({"_id": "special1", "text": text})


### PR DESCRIPTION
Add support for "batch=ok" inserts http://guide.couchdb.org/draft/performance.html#batch which offer slightly better performance on fast but asynchronous inserts where batch mode cannot be used.