### PR TITLE
Add a callback to handle heartbeats.

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -715,8 +715,9 @@ class Database(object):
             for line in resp.iter_lines(chunk_size=1):
                 # ignore heartbeats
                 if not line:
-                    continue
-                reader.on_message(json.loads(utils.force_text(line)))
+                    reader.on_heartbeat()
+                else:
+                    reader.on_message(json.loads(utils.force_text(line)))
         except exp.FeedReaderExited as e:
             reader.on_close()
 

--- a/pycouchdb/feedreader.py
+++ b/pycouchdb/feedreader.py
@@ -28,6 +28,14 @@ class BaseFeedReader(object):
         """
         pass
 
+    def on_heartbeat(self):
+        """
+        Callback method invoked when a hearbeat (empty line) is received
+        from the _changes stream. Override this to purge the reader's internal
+        buffers (if any) if it waited too long without receiving anything.
+        """
+        pass
+
 
 class SimpleFeedReader(BaseFeedReader):
     """


### PR DESCRIPTION
- Allow to handle heartbeats received from the _changes stream. If the
  feed reader has some internal buffers, they may now be purged on
  heartbeats, so that we don't have to wait until a change happens in
  the database.