### PR TITLE
No default value for "since".

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -708,7 +708,6 @@ class Database(object):
 
         # Possible options: "continuous", "longpoll"
         kwargs.setdefault("feed", "continuous")
-        kwargs.setdefault("since", 1)
 
         (resp, result) = self.resource("_changes").get(params=kwargs, stream=True)
         try:


### PR DESCRIPTION
- Do not set the "since" parameter to "1" by default. If there's no
  "since" parameter provided, couchdb start the changes stream from the
  first change. Also, the change sequence does not have to be a number
  (see how Cloudant do it).