### PR TITLE
Handle non-existent docs in `all`.

### DIFF
--- a/pycouchdb/client.py
+++ b/pycouchdb/client.py
@@ -393,17 +393,7 @@ class Database(object):
 
         def _iterate():
             for row in result["rows"]:
-                yield wrapper(row['doc'])
-
-        def _iterate_no_docs():
-            for row in result["rows"]:
-                doc = {"id": row['id'], "rev": row['value']['rev']}
-                yield wrapper(doc)
-
-        if params["include_docs"].upper() == "FALSE":
-            if as_list:
-                return list(_iterate_no_docs())
-            return _iterate_no_docs()
+                yield wrapper(row)
 
         if as_list:
             return list(_iterate())

--- a/tests.py
+++ b/tests.py
@@ -277,7 +277,7 @@ class DatabaseQueryTests(unittest.TestCase):
         self.assertIn("kk1", self.db)
 
     def test_all_01(self):
-        result = [x for x in self.db.all() if not x['_id'].startswith("_")]
+        result = [x for x in self.db.all() if not x['key'].startswith("_")]
         self.assertEqual(len(result), 3)
 
     def test_all_02(self):
@@ -285,15 +285,15 @@ class DatabaseQueryTests(unittest.TestCase):
         self.assertEqual(len(result), 2)
 
     def test_all_03(self):
-        result = list(self.db.all(keys=['kk1','kk2'], flat="_id"))
+        result = list(self.db.all(keys=['kk1','kk2'], flat="key"))
         self.assertEqual(result, ['kk1', 'kk2'])
 
     def test_all_04(self):
-        result = self.db.all(keys=['kk1','kk2'], flat="_id")
+        result = self.db.all(keys=['kk1','kk2'], flat="key")
         self.assertIsInstance(result, types.GeneratorType)
 
     def test_all_05(self):
-        result = self.db.all(keys=['kk1','kk2'], flat="_id", as_list=True)
+        result = self.db.all(keys=['kk1','kk2'], flat="key", as_list=True)
         self.assertIsInstance(result, list)
 
     def test_all_startkey_endkey(self):


### PR DESCRIPTION
- Do not process the results of a call to `_all_docs`, leave it for the
  wrapper that a user may pass in if they so wish. This prevents the
  `all` method from breaking when called with non-existent keys.
- Fix tests accordingly.